### PR TITLE
doc: Update Mapping Declaration Section

### DIFF
--- a/docs/intro/ink-vs-solidity.md
+++ b/docs/intro/ink-vs-solidity.md
@@ -276,19 +276,13 @@ mapping(address => uint128) private mapName;
 
 ```rust
 //ink!
-use ink_storage::{
-    traits::SpreadAllocate,
-    Mapping,
-};
+use ink::storage::Mapping;
 
 #[ink(storage)]
-#[derive(SpreadAllocate)]
 pub struct ContractName {
     map_name: Mapping<AccountId, u128>,
 }
 ```
-
-When using a map in ink!, `ink_lang::utils::initialize_contract` must be used in the constructor. See [here](../datastructures/mapping.md) for more details.
 
 ### `mapping usage`
 


### PR DESCRIPTION
Update ink! mapping syntax to conform with ink v4

## Description
- Removed unnecessary imports.
- Updated the ink! mapping syntax.
- Removed outdated reference to `ink_lang::utils::initialize_contract`.