### PR TITLE
Update `default` arg docs in relation to Solidity compatible metadata generation.

### DIFF
--- a/versioned_docs/version-4.x/macros-attributes/default.md
+++ b/versioned_docs/version-4.x/macros-attributes/default.md
@@ -8,7 +8,7 @@ hide_title: true
 
 Applicable to ink! messages and constructors.
 
-Works as a hint for UIs to determine if constuctor/message should be picked as default.
+Works as a hint for UIs to determine if constructor/message should be picked as default.
 
 At most one constructor or message can be marked as default.
 

--- a/versioned_docs/version-6.x/macros-attributes/default.md
+++ b/versioned_docs/version-6.x/macros-attributes/default.md
@@ -8,7 +8,9 @@ hide_title: true
 
 Applicable to ink! messages and constructors.
 
-Works as a hint for UIs to determine if constuctor/message should be picked as default.
+Works as a hint for UIs to determine if constructor/message should be picked as default.
+
+It's also used to select the constructor to include in Solidity compatible metadata.
 
 At most one constructor or message can be marked as default.
 


### PR DESCRIPTION
See title 🙂 