### PR TITLE
feat: add dedot & typink

### DIFF
--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -33,7 +33,7 @@ There are several levels of abstraction where you can start your journey creatin
 ### React
 
 + [`useInkathon`](https://github.com/scio-labs/use-inkathon) **(recommended)**: A hooks library for the popular frontend javascript framework React with focus on smart-contract interactions. Built using `@polkadot/api` & `@polkadot/api-contract`.
-+ [`typink`](https://docs.dedot.dev/typink) **(recommended)**: A comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamlines interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors.
++ [`typink`](https://docs.dedot.dev/typink) **(recommended)**: A comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamlines interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors. [Getting started now!](/getting-started/typink)
 
 ### React and Next.js
 

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -28,7 +28,7 @@ There are several levels of abstraction where you can start your journey creatin
 
 + [`@polkadot/api-contract`](https://polkadot.js.org/docs/api-contract) **(recommended)**: abstraction on top of `@polkadot/api` for the `pallet-contracts`. Makes interaction with smart contracts more comfortable and type safe.
 
-+ [`dedot`](https://docs.dedot.dev/ink-smart-contracts/intro) **(recommended)**: Next-gen TypeScript client for Polkadot & PolkadotSDK-based networks, offering fully type-safe APIs for interacting with ink! smart contracts. Dedot simplifies the process of generating TypeScript bindings for your contracts, deploying them, executing queries and transactions, performing dry runs for validation, and decoding contract events with full type safety.
++ [`dedot`](https://docs.dedot.dev/ink-smart-contracts/intro) **(recommended)**: Next-gen TypeScript client for Polkadot & Polkadot SDK-based networks, offering fully type-safe APIs for interacting with ink! smart contracts. Dedot simplifies the process of generating TypeScript bindings for your contracts, deploying them, executing queries and transactions, performing dry runs for validation, and decoding contract events with full type safety.
 
 ### React
 

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -28,9 +28,12 @@ There are several levels of abstraction where you can start your journey creatin
 
 + [`@polkadot/api-contract`](https://polkadot.js.org/docs/api-contract) **(recommended)**: abstraction on top of `@polkadot/api` for the `pallet-contracts`. Makes interaction with smart contracts more comfortable and type safe.
 
++ [`dedot`](https://docs.dedot.dev/ink-smart-contracts/intro) **(recommended)**: Next-gen TypeScript client for Polkadot & PolkadotSDK-based networks, offering fully type-safe APIs for interacting with ink! smart contracts. It eliminates the need for wrapped codec types, allowing developers to work seamlessly with TypeScript’s native type system. With Dedot, you can generate contract-specific types, deploy contracts, interact with them via query and transactions, perform dry runs for validation, and decode fully-typed contract events.
+
 ### React
 
 + [`useInkathon`](https://github.com/scio-labs/use-inkathon) **(recommended)**: A hooks library for the popular frontend javascript framework React with focus on smart-contract interactions. Built using `@polkadot/api` & `@polkadot/api-contract`.
++ [`typink`](https://docs.dedot.dev/typink) **(recommended)**: A fully type-safe React hooks library designed to streamline ink! smart contract interactions. Built on Dedot, it ensures reliable contract messaging, contract event handling, and wallet authentication while supporting multi-chain deployments. With flexible wallet integration, a lightweight architecture, and a built-in CLI for generating boilerplate dApp projects, Typink makes ink! dApp development more efficient, high-performance, and developer-friendly.
 
 ### React and Next.js
 

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -28,12 +28,12 @@ There are several levels of abstraction where you can start your journey creatin
 
 + [`@polkadot/api-contract`](https://polkadot.js.org/docs/api-contract) **(recommended)**: abstraction on top of `@polkadot/api` for the `pallet-contracts`. Makes interaction with smart contracts more comfortable and type safe.
 
-+ [`dedot`](https://docs.dedot.dev/ink-smart-contracts/intro) **(recommended)**: Next-gen TypeScript client for Polkadot & PolkadotSDK-based networks, offering fully type-safe APIs for interacting with ink! smart contracts. It eliminates the need for wrapped codec types, allowing developers to work seamlessly with TypeScript’s native type system. With Dedot, you can generate contract-specific types, deploy contracts, interact with them via query and transactions, perform dry runs for validation, and decode fully-typed contract events.
++ [`dedot`](https://docs.dedot.dev/ink-smart-contracts/intro) **(recommended)**: Next-gen TypeScript client for Polkadot & PolkadotSDK-based networks, offering fully type-safe APIs for interacting with ink! smart contracts. Dedot simplifies the process of generating TypeScript bindings for your contracts, deploying them, executing queries and transactions, performing dry runs for validation, and decoding contract events with full type safety.
 
 ### React
 
 + [`useInkathon`](https://github.com/scio-labs/use-inkathon) **(recommended)**: A hooks library for the popular frontend javascript framework React with focus on smart-contract interactions. Built using `@polkadot/api` & `@polkadot/api-contract`.
-+ [`typink`](https://docs.dedot.dev/typink) **(recommended)**: A fully type-safe React hooks library designed to streamline ink! smart contract interactions. Built on Dedot, it ensures reliable contract messaging, contract event handling, and wallet authentication while supporting multi-chain deployments. With flexible wallet integration, a lightweight architecture, and a built-in CLI for generating boilerplate dApp projects, Typink makes ink! dApp development more efficient, high-performance, and developer-friendly.
++ [`typink`](https://docs.dedot.dev/typink) **(recommended)**: A comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamlines interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors.
 
 ### React and Next.js
 

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -7,7 +7,7 @@ slug: /getting-started/typink
 
 ## Overview
 
-Typink is a comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamlines interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors (e.g: [SubConnect](https://github.com/Koniverse/SubConnect-v2), [Talisman Connect](https://github.com/TalismanSociety/talisman-connect), ...).
+Typink is a comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamline interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors (e.g: [SubConnect](https://github.com/Koniverse/SubConnect-v2), [Talisman Connect](https://github.com/TalismanSociety/talisman-connect), ...).
 
 ## Why Typink?
 

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -39,7 +39,7 @@ Typink provides a type-safe, flexible, and efficient way to build ink! dApps:
 
 ## Join the community
 
-Join the [Dedot & Typink Telegram Group](https://t.me/JoinDedot) to ask questions, share ideas, and collaborate on ink! dApp development! Whether you’re looking for support or want to contribute, we’d love to have you on board. [Join us now!](https://t.me/JoinDedot)
+Join the [Dedot & Typink Telegram Group](https://t.me/JoinDedot) to ask questions, share ideas, and collaborate on ink! dApps development! Whether you’re looking for support or want to contribute, we’d love to have you on board. [Join us now!](https://t.me/JoinDedot)
 
 ---
 **Build with confidence. Build with Typink.**

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -1,0 +1,38 @@
+---
+title: Typink
+slug: /getting-started/typink
+---
+
+# Introducing Typink
+
+Typesafe React hooks for seamless ink! smart contract interactions, powered by Dedot!
+
+## Overview
+
+ink! is a powerful smart contract language in the Polkadot ecosystem, but integrating with its contracts can be challenging. Developers often struggle with type safety, event handling, and wallet authentication.
+
+Typink solves these challenges by offering a modern, fully type-safe React hooks library for ink! dApp development.
+
+## Why Typink?
+
+Typink provides a type-safe, flexible, and efficient way to build ink! dApps:
+
+✅ Fully Type-Safe React Hooks – Ensures reliability in contract interactions. <br/>
+✅ Built-in CLI – Kickstart projects in seconds with create-typink. <br/>
+✅ Decoupled Wallet Integration – Supports various wallet connectors or custom implementations. <br/>
+✅ Multi-Chain Support – Effortlessly switch networks with lazy initialization. <br/>
+
+
+## Get Started
+
+Dive into our tutorial and experience the difference:
+📖 Tutorial: Develop an ink! dApp using Typink
+🔗 GitHub Repo: psp22-transfer
+
+## Conclusion
+
+Typink makes ink! dApp development easier, faster, and more reliable. With type safety, flexibility, and performance at its core, it streamlines development and reduces errors.
+
+Build with confidence. Build with Typink.
+
+This keeps it direct, impactful, and easy to read. 🚀

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -7,7 +7,7 @@ slug: /getting-started/typink
 
 ## Overview
 
-Typink is a comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamline interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors (e.g: [SubConnect](https://github.com/Koniverse/SubConnect-v2), [Talisman Connect](https://github.com/TalismanSociety/talisman-connect), ...).
+Typink is a comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamline interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors (e.g. [SubConnect](https://github.com/Koniverse/SubConnect-v2), [Talisman Connect](https://github.com/TalismanSociety/talisman-connect), ...).
 
 ## Why Typink?
 

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -5,34 +5,41 @@ slug: /getting-started/typink
 
 # Introducing Typink
 
-Typesafe React hooks for seamless ink! smart contract interactions, powered by Dedot!
-
 ## Overview
 
-ink! is a powerful smart contract language in the Polkadot ecosystem, but integrating with its contracts can be challenging. Developers often struggle with type safety, event handling, and wallet authentication.
-
-Typink solves these challenges by offering a modern, fully type-safe React hooks library for ink! dApp development.
+Typink is a comprehensive toolkit designed to simplify and accelerate ink! dApp development. Typink provides fully type-safe React hooks to streamlines interactions with ink! smart contracts, ensuring a seamless developer experience. With its built-in CLI, Typink enables you to bootstrap new projects in seconds, offering multi-chain support and flexible options for wallet connectors (e.g: [SubConnect](https://github.com/Koniverse/SubConnect-v2), [Talisman Connect](https://github.com/TalismanSociety/talisman-connect), ...).
 
 ## Why Typink?
 
 Typink provides a type-safe, flexible, and efficient way to build ink! dApps:
 
 ✅ Fully Type-Safe React Hooks – Ensures reliability in contract interactions. <br/>
-✅ Built-in CLI – Kickstart projects in seconds with create-typink. <br/>
+✅ Built-in CLI – Kickstart projects in seconds with `create-typink`. <br/>
 ✅ Decoupled Wallet Integration – Supports various wallet connectors or custom implementations. <br/>
 ✅ Multi-Chain Support – Effortlessly switch networks with lazy initialization. <br/>
 
 
-## Get Started
+## Quick look
 
-Dive into our tutorial and experience the difference:
-📖 Tutorial: Develop an ink! dApp using Typink
-🔗 GitHub Repo: psp22-transfer
+1. Fully Type-Safe React Hooks
 
-## Conclusion
+![Fully Type-Safe React Hooks](https://docs.dedot.dev/~gitbook/image?url=https%3A%2F%2F486742009-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FMrQp7F5eE70nr7yUHeEZ%252Fuploads%252F0O9vuGWWnB13Bt1sW28o%252Ftypink-suggestions.gif%3Falt%3Dmedia%26token%3Dd4ac08dc-0286-42ad-835a-a53038f7a74c&width=768&dpr=2&quality=100&sign=f35c0200&sv=2)
 
-Typink makes ink! dApp development easier, faster, and more reliable. With type safety, flexibility, and performance at its core, it streamlines development and reduces errors.
+2. Built-in CLI `create-typink` to spin up new projects in seconds
 
-Build with confidence. Build with Typink.
+![create-typink](https://docs.dedot.dev/~gitbook/image?url=https%3A%2F%2F486742009-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FMrQp7F5eE70nr7yUHeEZ%252Fuploads%252FqzCwGVTJqyrqi8MSC6aW%252Fimage.png%3Falt%3Dmedia%26token%3D03aacbe8-996c-4c32-8284-c340570e512a&width=768&dpr=2&quality=100&sign=489982ed&sv=2)
 
-This keeps it direct, impactful, and easy to read. 🚀
+## Get started
+
+- [Start a new Typink dApp project](https://docs.dedot.dev/typink/getting-started/start-a-new-dapp)
+- [Migrate from an existing dApp](https://docs.dedot.dev/typink/getting-started/migrate-from-existing-dapp)
+- [Documentation](https://docs.dedot.dev/typink)
+- [GitHub Repository](https://github.com/dedotdev/typink)
+- [Tutorial: Develop a PSP22 Transfer dApp with Typink](https://docs.dedot.dev/help-and-faq/tutorials/develop-ink-dapp-using-typink)
+
+## Join the community
+
+Join the [Dedot & Typink Telegram Group](https://t.me/JoinDedot) to ask questions, share ideas, and collaborate on ink! dApp development! Whether you’re looking for support or want to contribute, we’d love to have you on board. [Join us now!](https://t.me/JoinDedot)
+
+---
+**Build with confidence. Build with Typink.**

--- a/docs/third-party-tools/typink.md
+++ b/docs/third-party-tools/typink.md
@@ -39,7 +39,7 @@ Typink provides a type-safe, flexible, and efficient way to build ink! dApps:
 
 ## Join the community
 
-Join the [Dedot & Typink Telegram Group](https://t.me/JoinDedot) to ask questions, share ideas, and collaborate on ink! dApps development! Whether you’re looking for support or want to contribute, we’d love to have you on board. [Join us now!](https://t.me/JoinDedot)
+Join the [Dedot & Typink Telegram Group](https://t.me/JoinDedot) to ask questions, share ideas, and collaborate on ink! dApp development! Whether you’re looking for support or want to contribute, we’d love to have you on board. [Join us now!](https://t.me/JoinDedot)
 
 ---
 **Build with confidence. Build with Typink.**

--- a/sidebars.js
+++ b/sidebars.js
@@ -129,7 +129,8 @@ module.exports = {
         }
       },
       "third-party-tools/ink-analyzer",
-      "third-party-tools/subwallet"
+      "third-party-tools/subwallet",
+      "third-party-tools/typink"
     ],
     "FAQ": [
       "faq/faq",


### PR DESCRIPTION
Hello there 👋

I’d like to add [Dedot](https://docs.dedot.dev) and [Typink](https://docs.dedot.dev/typink) to the list of supported client and frontend toolkits for ink! dApp development. With robust and comprehensive support for ink! contract interactions—including type-safe APIs, CLI tools, and more—Dedot and Typink offer a strong alternative alongside existing toolkits and libraries in the ecosystem, giving developers more options when building their next ink! dApp.

Let us know if you have any questions or need adjustments in the changes. Thank you!