### PR TITLE
Updated Link for Cross-Contract Calls Example

### DIFF
--- a/docs/examples/contracts.md
+++ b/docs/examples/contracts.md
@@ -67,7 +67,7 @@ Some of the most interesting ones:
 
 <div className="row">
     <div className="col text--center">
-        <a href="hhttps://github.com/use-ink/ink-examples/tree/main/cross-contract-calls"><img src="/img/icons/delegator.svg" width="100" /></a>
+        <a href="https://github.com/use-ink/ink-examples/tree/main/cross-contract-calls"><img src="/img/icons/delegator.svg" width="100" /></a>
         <p>
             Cross-contract calls.<br/>
             <a href="https://github.com/use-ink/ink-examples/tree/main/cross-contract-calls">» view example</a>

--- a/docs/examples/contracts.md
+++ b/docs/examples/contracts.md
@@ -67,10 +67,10 @@ Some of the most interesting ones:
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/use-ink/ink-examples/tree/main/upgradeable-contracts/delegator"><img src="/img/icons/delegator.svg" width="100" /></a>
+        <a href="hhttps://github.com/use-ink/ink-examples/tree/main/cross-contract-calls"><img src="/img/icons/delegator.svg" width="100" /></a>
         <p>
             Cross-contract calls.<br/>
-            <a href="https://github.com/use-ink/ink-examples/tree/main/upgradeable-contracts/delegator">» view example</a>
+            <a href="https://github.com/use-ink/ink-examples/tree/main/cross-contract-calls">» view example</a>
         </p>
     </div>
     <div className="col text--center">


### PR DESCRIPTION
### Fixed Link to Cross-Contract Calls Example

This update corrects the link to the cross-contract calls example in the **ink!** smart contract repository. Previously, the example pointed to the **upgradeable-contracts/delegator** directory, which was incorrect. The corrected version now links to the appropriate **cross-contract-calls** directory, ensuring that users can easily access the relevant example for learning about cross-smart contract interactions in **ink!**. 

This update improves accuracy and enhances the user experience by directing them to the correct resource.
