### PR TITLE
Replace references to `cargo test` with `cargo contract test` in ink! v6 docs

### DIFF
--- a/versioned_docs/version-v6/background/ink-vs-cosmwasm.md
+++ b/versioned_docs/version-v6/background/ink-vs-cosmwasm.md
@@ -135,7 +135,7 @@ $ cargo contract build
 and tested via:
 
 ```
-$ cargo test
+$ cargo contract test
 ```
 
 ### Deploy and Interact

--- a/versioned_docs/version-v6/background/ink-vs-solidity.md
+++ b/versioned_docs/version-v6/background/ink-vs-solidity.md
@@ -878,7 +878,7 @@ mycontract = { path = "mycontract/", default-features = false, features = ["ink-
 ## unit testing (off-chain)
 
 - Unit tests are an integral part of smart-contract development and ensuring your code works off-chain before testing on-chain.
-- To run ink! tests, use the command `cargo test`. Add the `--nocapture` flag for debug prints to show.
+- To run ink! tests, use the command `cargo contract test`. Add the `--nocapture` flag for debug prints to show.
 - From the contract module, make sure to make the contract struct and anything else that is going to be used in the unit tests public. For example:
 
 ```rust

--- a/versioned_docs/version-v6/basics/contract-template.md
+++ b/versioned_docs/version-v6/basics/contract-template.md
@@ -29,7 +29,7 @@ In the `lib.rs` file you find initial scaffolded code, which you can use as a st
 Quickly check that it compiles, and the trivial tests pass with:
 
 ```bash
-$ cargo test
+$ cargo contract test
 ```
 
 Also check that you can build the contract by running:
@@ -38,8 +38,8 @@ Also check that you can build the contract by running:
 $ cargo contract build
 ```
 
-`cargo test` builds the contract for `std`, `cargo contract build` for an 
-on-chain deployment (`no_std` with a RISC-V target).
+`cargo contract test` builds the contract for `std`, 
+`cargo contract build` for an on-chain deployment (`no_std` with a RISC-V target).
 
 If everything looks good, then we are ready to start programming!
 
@@ -84,7 +84,7 @@ std = [
 ink-as-dependency = []
 
 # This feature is just a convention, so that the end-to-end tests
-# are only executed if `cargo test` is explicitly invoked with
+# are only executed if `cargo contract test` is explicitly invoked with
 # `--features e2e-tests`.
 e2e-tests = []
 ```

--- a/versioned_docs/version-v6/getting-started/creating.md
+++ b/versioned_docs/version-v6/getting-started/creating.md
@@ -52,13 +52,13 @@ At the bottom of the `lib.rs` you'll see some simple test cases which verify the
 We can quickly test this code is functioning as expected:
 
 ```bash
-$ cargo test
+$ cargo contract test
 ```
 
 To which you should see a successful test completion:
 
 ```bash
-$ cargo test
+$ cargo contract test
 running 2 tests
 test flipper::tests::it_works ... ok
 test flipper::tests::default_works ... ok

--- a/versioned_docs/version-v6/testing/e2e.md
+++ b/versioned_docs/version-v6/testing/e2e.md
@@ -81,5 +81,5 @@ $ export CONTRACTS_NODE="YOUR_CONTRACTS_NODE_PATH"
 And finally execute the following command to start e2e test execution.
 
 ```bash
-$ cargo test --features e2e-tests
+$ cargo contract test --features e2e-tests
 ```

--- a/versioned_docs/version-v6/testing/testing-with-live-state.md
+++ b/versioned_docs/version-v6/testing/testing-with-live-state.md
@@ -208,7 +208,7 @@ export CONTRACT_HEX=0x2c75f0aa09dbfbfd49e6286a0f2edd3b4913f04a58b13391c79e96782f
 # process (typically of `ink-node`) for each test.
 export CONTRACTS_NODE_URL=ws://127.0.0.1:8000
 
-cargo test --features e2e-tests e2e_test_deployed_contract -- --ignored
+cargo contract test --features e2e-tests e2e_test_deployed_contract -- --ignored
 ```
 
 You will get output similar to the following:

--- a/versioned_docs/version-v6/testing/unit-integration.md
+++ b/versioned_docs/version-v6/testing/unit-integration.md
@@ -12,7 +12,7 @@ On this page we lay out the different use-cases for unit vs. integration tests.
 
 ## Unit Tests
 
-Testing contracts off-chain is done by `cargo test` and users can simply use the standard Rust
+Testing contracts off-chain is done by `cargo contract test` and users can simply use the standard Rust
 routines of creating unit test modules within the ink! project:
 
 ```rust


### PR DESCRIPTION
See https://github.com/use-ink/cargo-contract/pull/2034 for details