### PR TITLE
fix: add -x flag in cross-contract calling guide

### DIFF
--- a/docs/basics/cross-contract-calling.md
+++ b/docs/basics/cross-contract-calling.md
@@ -152,7 +152,7 @@ We can upload `OtherContract` using `cargo-contract` as follows:
 ```
 # In the `basic_contract_ref` directory
 cargo contract build --manifest-path other_contract/Cargo.toml
-cargo contract upload --manifest-path other_contract/Cargo.toml --suri //Alice
+cargo contract upload --manifest-path other_contract/Cargo.toml --suri //Alice -x
 ```
 
 If successful, this will output in a `code_hash` similar to:

--- a/versioned_docs/version-v5/basics/cross-contract-calling.md
+++ b/versioned_docs/version-v5/basics/cross-contract-calling.md
@@ -146,7 +146,7 @@ We can upload `OtherContract` using `cargo-contract` as follows:
 ```
 # In the `basic_contract_ref` directory
 cargo contract build --manifest-path other_contract/Cargo.toml
-cargo contract upload --manifest-path other_contract/Cargo.toml --suri //Alice
+cargo contract upload --manifest-path other_contract/Cargo.toml --suri //Alice -x
 ```
 
 If successful, this will output in a `code_hash` similar to:


### PR DESCRIPTION
Reported by a user on Telegram. Following the cross contract call guide led to this error:
```
Pre-submission dry-run failed: ModuleError: Revive::CodeNotFound: ["No code could be found at the supplied code hash."]
```
Cause: the command must be executed with the `-x` flag.
