### PR TITLE
docs: corrected library name typo

### DIFF
--- a/docs/faq/migrating-from-ink-5-to-6.md
+++ b/docs/faq/migrating-from-ink-5-to-6.md
@@ -55,7 +55,7 @@ mentioned above.
 For the above mentioned four functions please see the respective sections on this page,
 there we explain how to find out if a chain supports them there.
 
-You can use the [polakdot.js app](https://polkadot.js.org/apps/) to connect to the chain and check if
+You can use the [polkadot.js app](https://polkadot.js.org/apps/) to connect to the chain and check if
 `reviveApi` is available under Developer » Runtime calls.
 
 <img src={useBaseUrl('/img/pallet-revive-available.png')} />


### PR DESCRIPTION
<img width="958" height="238" alt="Снимок экрана 2025-08-26 в 13 34 32" src="https://github.com/user-attachments/assets/7d41b313-cf0b-42d1-89e4-7bc44fca2a4b" />
changed “polakdot.js” to “polkadot.js” so everything matches.