### PR TITLE
`docs: Fix variable name mismatch in constructor example`

### DIFF
--- a/versioned_docs/version-v5/basics/events.md
+++ b/versioned_docs/version-v5/basics/events.md
@@ -191,7 +191,7 @@ See this example:
 
 ```rust
 #[ink(constructor)]
-pub fn new(initial_value: Balance) -> Self {
+pub fn new(initial_supply: Balance) -> Self {
     let caller = Self::env().caller();
     let mut balances = HashMap::new();
     balances.insert(caller, initial_supply);


### PR DESCRIPTION
The code example for the Erc20 new constructor in the documentation contained a typo that would prevent it from compiling.

The function signature defined the input parameter as initial_value,but the function body attempted to use an undefined variable named initial_supply.

This change renames the parameter in the function signature from initial_value to initial_supply to match its usage throughout the function body. This makes the code example correct, consistent, and runnable.

#[ink(constructor)]
pub fn new(initial_value: Balance) -> Self { //initial_value must be initial_supply
    let caller = Self::env().caller();
    let mut balances = HashMap::new();
    balances.insert(caller, initial_supply);

    Self::env().emit_event(Transferred {
        from: None,
        to: Some(caller),
        amount: initial_supply
    });

    Self { total_supply: initial_supply, balances }
}