### PR TITLE
feat: add typink to dApp templates section

### DIFF
--- a/docs/intro/sub0-hackathon.mdx
+++ b/docs/intro/sub0-hackathon.mdx
@@ -140,6 +140,7 @@ We recommend the following tools to help you quickly scaffold dApp projects:
 
 - Provides ready-to-use dApp templates combining ink! smart contracts and frontend integration.
 - You can find a hardcoded frontend for our `flipper` example [here](https://github.com/use-ink/ink-examples/tree/main/flipper).
+
 ### 2. [Typink](https://typink.dev)
 
 - A fully type-safe React hooks library with a [CLI](https://docs.dedot.dev/typink/create-typink-cli) for instant project scaffolding.


### PR DESCRIPTION
This PR add Typink to dApp templates section of [sub0 page](https://use.ink/docs/v6/sub0-hackathon-2025)

Let me know if you have any thoughts/feedback, thanks!

cc: @Daanvdplas 